### PR TITLE
Forgot Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "illacceptanything"
+version = "0.0.1"
+authors = ["Scott Cooper"]


### PR DESCRIPTION
Forgot to include Cargo.toml for the package name, version, authors, etc, as well as dependencies.