### PR TITLE
Added the useful macro PRINT-UNREADABLE-SAFELY

### DIFF
--- a/cl/misc.lisp
+++ b/cl/misc.lisp
@@ -1,0 +1,19 @@
+;;;
+;;;  Useful function that ensures that unbound slots don't cause a
+;;;  recursive error when trying to print a stack trace.
+;;;
+
+(defmacro print-unreadable-safely ((&rest slots) object stream &body body)
+  "A version of PRINT-UNREADABLE-OBJECT and WITH-SLOTS that is safe to use with unbound slots"
+  (let ((object-copy (gensym "OBJECT"))
+        (stream-copy (gensym "STREAM")))
+    `(let ((,object-copy ,object)
+           (,stream-copy ,stream))
+       (symbol-macrolet ,(mapcar #'(lambda (slot-name)
+                                     `(,slot-name (if (and (slot-exists-p ,object-copy ',slot-name)
+                                                           (slot-boundp ,object-copy ',slot-name))
+                                                      (slot-value ,object-copy ',slot-name)
+                                                      :not-bound)))
+                                 slots)
+         (print-unreadable-object (,object-copy ,stream-copy :type t :identity nil)
+           ,@body)))))


### PR DESCRIPTION
This macro is really useful in most Common Lisp applications