### PR TITLE
Adding a single test case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components/
 .gitignore
+*


### PR DESCRIPTION
Adding a test to validate resiliency of the 'merge *anything*' case.  A failed test may indicate the entire project thus far hasn't passed spec.