### PR TITLE
Elevating contribution diversity by means of i18n

### DIFF
--- a/data/i18y4a11y.properties
+++ b/data/i18y4a11y.properties
@@ -1,0 +1,1 @@
+org.illacceptanything.de.user.preference.sausage=Hund.. no wait. Wasn't it Wurst?


### PR DESCRIPTION
Projects disregarding i18n and a11y are frowned upon these days. This change guarantees a 400% improvement in developer acceptance rate.