### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,19 +355,19 @@ ps.imapankace
 
 ### Linux x Mac x Windows for dev
 
-- 1   Linux
+- 2   Linux
 - 0   Mac
 - 0   Windows
 
 ### Linux x Mac x Windows for gaming
 
-- 0.5   Linux
+- 0.75   Linux
 - 0     Mac
-- 0.5   Windows
+- 1.25   Windows
 
 ### Linux x Mac x Windows you are using right now
 
-- 1   Linux
+- 2   Linux
 - 1   Mac
-- 0   Windows
+- -1   Windows
 


### PR DESCRIPTION
to explain the -1 for windows - NTFS doesn't like long filepaths and (for NTFS) illegal characters, making cloning this repo either impossible or extremely inconvenient. So I booted into Linux.